### PR TITLE
Manual changes for comments resolution

### DIFF
--- a/Internet-Drafts/Use-Case-1-Analysis/01/use-case-1-topology-01.json
+++ b/Internet-Drafts/Use-Case-1-Analysis/01/use-case-1-topology-01.json
@@ -1,16 +1,15 @@
-"// Reference drafts " : [
-  "ietf-network-topology (draft-ietf-i2rs-yang-network-topo-12)",
-  "ietf-te-topology (draft-ietf-teas-yang-te-topo-09)",
-  "ietf-otn-topology (draft-ietf-ccamp-otn-topo-yang-00)"
-]
 {
+  "// Reference drafts ": [
+    "ietf-network-topology (draft-ietf-i2rs-yang-network-topo-12)",
+    "ietf-te-topology (draft-ietf-teas-yang-te-topo-09)",
+    "ietf-otn-topology (draft-ietf-ccamp-otn-topo-yang-00)"
+  ],
   "ietf-network:networks": {
     "network": [
       {
         "// comment": "ODU Abstract Topology @ MPI",
         "network-id": "Abstract-Topology",
-        "// comment-1":
-          "Missing I2RS attributes - to be added in a future update",
+        "// comment-1": "Missing I2RS attributes - to be added in a future update",
         "// provider-id": "To be discussed",
         "// client-id": "To be discussed",
         "// te-topology-id": "To be discussed",
@@ -21,6 +20,7 @@
         },
         "node": [
           {
+            "// comment": "S3 Node",
             "// comment-1": [
               "Missing I2RS attributes - to be added in a future update"
             ],
@@ -33,109 +33,106 @@
             "ietf-network:node-id": "of:0000000000000003",
             "ietf-network-topology:termination-point": [
               {
+                "// comment": "S3-1 LTP",
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "3"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "4"
@@ -156,54 +153,52 @@
             "ietf-network-topology:termination-point": [
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
@@ -224,54 +219,52 @@
             "ietf-network-topology:termination-point": [
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
@@ -292,81 +285,78 @@
             "ietf-network-topology:termination-point": [
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "3"
@@ -387,81 +377,78 @@
             "ietf-network-topology:termination-point": [
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "3"
@@ -469,6 +456,7 @@
             ]
           },
           {
+            "// comment": "S8 Node",
             "// comment-1": [
               "Missing I2RS attributes - to be added in a future update"
             ],
@@ -482,108 +470,104 @@
             "ietf-network-topology:termination-point": [
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "3"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "4"
@@ -604,81 +588,78 @@
             "ietf-network-topology:termination-point": [
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "3"
@@ -686,6 +667,7 @@
             ]
           },
           {
+            "// comment": "S6 Node",
             "// comment-1": [
               "Missing I2RS attributes - to be added in a future update"
             ],
@@ -698,109 +680,107 @@
             "ietf-network:node-id": "of:0000000000000006",
             "ietf-network-topology:termination-point": [
               {
+                "// comment": "S6-1 LTP",
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "1"
               },
               {
+                "// comment": "S6-2 LTP",
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "2"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "3"
               },
               {
                 "// comment-1": [
-                 "Missing I2RS attributes - to be added in a future",
+                  "Missing I2RS attributes - to be added in a future",
                   " update"
                 ],
                 "ietf-te-topology:te": {
                   "state": {
                     "// adaptation-type": " ccamp-otn-topo-yang-00",
                     "// comment": [
-                     "Agumentation from",
+                      "Agumentation from",
                       " draft-ietf-ccamp-otn-topo-yang-00"
                     ],
                     "// sink-adapt-active": "To be discussed",
                     "// source-adapt-active": "To be discussed",
                     "// supported-payload-types": "To be discussed",
                     "// tpn": "To be discussed",
-                    "// tributary-slots": " TSs at 1,25TS granularity)",
+                    "// tributary-slots": " TSs at 1,25TS granularity (80 available)",
                     "// tsg": "To be discussed",
                     "ietf-otn-topology:client-facing": [
                       null
                     ],
-                    "ietf-otn-topology:protocol-type":
-                      "ietf-transport-types:prot-OTU4"
+                    "ietf-otn-topology:protocol-type": "ietf-transport-types:prot-OTU4"
                   }
                 },
                 "ietf-network-topology:tp-id": "4"
@@ -809,6 +789,75 @@
           }
         ],
         "ietf-network-topology:link": [
+          {
+            "// comment": "Access Link between S3 and C-R1",
+            "// comment-1": [
+              "Missing I2RS attributes - to be added in a future update"
+            ],
+            "ietf-te-topology:te": {
+              "state": {
+                "te-link-attributes": {
+                  "admin-status": "up",
+                  "name": "Access Link between S3 and C-R1",
+                  "access-type": "point-to-point",
+                  "external-domain": {
+                    "// comment": [
+                      "Information needed to glue this",
+                      "access link with C-R1",
+                      "(to be further analysed)"
+                    ]
+                  }
+                }
+              }
+            },
+            "link-id": "S3_C-R1"
+          },
+          {
+            "// comment": "Access Link between S6 and C-R2",
+            "// comment-1": [
+              "Missing I2RS attributes - to be added in a future update"
+            ],
+            "ietf-te-topology:te": {
+              "state": {
+                "te-link-attributes": {
+                  "admin-status": "up",
+                  "name": "Access Link between S6 and C-R2",
+                  "access-type": "point-to-point",
+                  "external-domain": {
+                    "// comment": [
+                      "Information needed to glue this",
+                      "access link with C-R2",
+                      "(to be further analysed)"
+                    ]
+                  }
+                }
+              }
+            },
+            "link-id": "S6_C-R2"
+          },
+          {
+            "// comment": "Access Link between S6 and C-R3",
+            "// comment-1": [
+              "Missing I2RS attributes - to be added in a future update"
+            ],
+            "ietf-te-topology:te": {
+              "state": {
+                "te-link-attributes": {
+                  "admin-status": "up",
+                  "name": "Access Link between S6 and C-R3",
+                  "access-type": "point-to-point",
+                  "external-domain": {
+                    "// comment": [
+                      "Information needed to glue this",
+                      "access link with C-R3",
+                      "(to be further analysed)"
+                    ]
+                  }
+                }
+              }
+            },
+            "link-id": "S6_C-R3"
+          },
           {
             "// comment-1": [
               "Missing I2RS attributes - to be added in a future update"
@@ -820,7 +869,7 @@
                   "name": "of:0000000000000001_of:0000000000000003",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -838,7 +887,7 @@
                   "name": "of:0000000000000003_of:0000000000000004",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -856,7 +905,7 @@
                   "name": "of:0000000000000005_of:0000000000000006",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -874,7 +923,7 @@
                   "name": "of:0000000000000003_of:0000000000000005",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -892,7 +941,7 @@
                   "name": "of:0000000000000005_of:0000000000000007",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -910,7 +959,7 @@
                   "name": "of:0000000000000004_of:0000000000000008",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -928,7 +977,7 @@
                   "name": "of:0000000000000002_of:0000000000000008",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -946,7 +995,7 @@
                   "name": "of:0000000000000008_of:0000000000000002",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -964,7 +1013,7 @@
                   "name": "of:0000000000000003_of:0000000000000001",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -982,7 +1031,7 @@
                   "name": "of:0000000000000007_of:0000000000000005",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1000,7 +1049,7 @@
                   "name": "of:0000000000000008_of:0000000000000004",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1018,7 +1067,7 @@
                   "name": "of:0000000000000005_of:0000000000000003",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1036,7 +1085,7 @@
                   "name": "of:0000000000000002_of:0000000000000001",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1054,7 +1103,7 @@
                   "name": "of:0000000000000008_of:0000000000000007",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1072,7 +1121,7 @@
                   "name": "of:0000000000000007_of:0000000000000006",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1090,7 +1139,7 @@
                   "name": "of:0000000000000006_of:0000000000000005",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1108,7 +1157,7 @@
                   "name": "of:0000000000000004_of:0000000000000003",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1126,7 +1175,7 @@
                   "name": "of:0000000000000006_of:0000000000000007",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1144,7 +1193,7 @@
                   "name": "of:0000000000000001_of:0000000000000002",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }
@@ -1162,7 +1211,7 @@
                   "name": "of:0000000000000007_of:0000000000000008",
                   "access-type": "point-to-point",
                   "external-domain": {
-                    "// comment": "Information needed to glue this"
+                    "// comment": "Empty container (internal link)"
                   }
                 }
               }


### PR DESCRIPTION
1) added manually some comments (see pull request review)

* Line 23:  "// comment": "S3 Node",
* Line 36:  "// comment": "S3-1 LTP",
* Line 459: "// comment": "S8 Node",
* Line 670: "// comment": "S6 Node",
* Line 683: "// comment": "S6-1 LTP",
* Line 710: "// comment": "S6-2 LTP",

2) Global change to the comment on the tributary-slots (see pull request review)

For example, line 52: "// tributary-slots": " TSs at 1,25TS granularity (80 available)",

3) Added the three access links

* Line 792-814:  Access Link between S3 and C-R1
* Lines 815-837: Access Link between S6 and C-R2
* Lines 838-860: Access Link between S6 and C-R3

4) Global change the comments on the external-domain container for internal links

For example, line 872: "// comment": "Empty container (internal link)"